### PR TITLE
Refactor slide rendering with shared Puppeteer helper

### DIFF
--- a/src/utils/puppeteer_helper.js
+++ b/src/utils/puppeteer_helper.js
@@ -1,0 +1,41 @@
+const puppeteer = require('puppeteer');
+
+const COMMON_CSS = `
+    body {
+        background: white !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        display: block !important;
+        min-height: auto !important;
+    }
+    .slide, section.slide, div.slide {
+        width: 1920px !important;
+        height: 1080px !important;
+        margin: 0 !important;
+        box-shadow: none !important;
+        border: none !important;
+        overflow: hidden !important;
+    }
+`;
+
+async function launchBrowser() {
+    return puppeteer.launch({
+        headless: 'new',
+        args: [
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--disable-dev-shm-usage',
+            '--disable-gpu'
+        ]
+    });
+}
+
+async function injectCommonCSS(page) {
+    await page.addStyleTag({ content: COMMON_CSS });
+}
+
+module.exports = {
+    launchBrowser,
+    injectCommonCSS,
+    COMMON_CSS
+};


### PR DESCRIPTION
## Summary
- add helper for launching Puppeteer and injecting shared slide CSS
- render slides in parallel with a concurrency limit for PDF generation and screenshots
- ensure pages are styled consistently and cleaned up on error

## Testing
- `node -e "require('./src/utils/puppeteer_helper.js')"`
- `node -e "require('./src/utils/pdf_generator.js')"`
- `node -e "require('./src/utils/screenshotter.js')"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e98056bc832a948b5a2826ab688d